### PR TITLE
Feature/enlarge format

### DIFF
--- a/dtx/ktx-base.dtx
+++ b/dtx/ktx-base.dtx
@@ -159,13 +159,15 @@
 % \subsection{Call the Base Class}
 % \label{sec:call-base-class}
 %
-% Call the following options for the parent class:
+% The parent class is called with a pre-defined set of options.
+% The following options are called explicitly:
 % \begin{itemize}
 % \item Put the bibliography to the table of contents.
 % \item Use a font size of 11 points.
 % \item Use a two-sided layout.
-% \item Calculate the optimal page division factor (see KOMA script
+% \item Set the page division factor to 9 (see KOMA script
 %   documentation).
+% \item Make the title page a cover page with custom margins.
 % \end{itemize}
 %    \begin{macrocode}
 \PassOptionsToClass{bibliography = totoc,%
@@ -178,9 +180,9 @@
 %
 % \noindent
 % This class is based on the scrbook class from the KOMA script
-% family. The class will be loaded with the following options by
-% default (options in parentheses are the default values of
-% scrtartcl):
+% family. In total, the following table gives an overview of all
+% options transferred to the base class (options in parentheses are
+% the default values of scrtartcl and therefore called implicitly):
 %   \begin{table}[ht]
 %     \centering
 %     \begin{tabular}{ll}

--- a/dtx/ktx-base.dtx
+++ b/dtx/ktx-base.dtx
@@ -124,6 +124,7 @@
 % \begin{macro}{style options}
 %   These options affect the style of the document.
 %    \begin{macrocode}
+\DeclareStringOption[standard]{format}
 \DeclareStringOption[false]{font}
 \DeclareStringOption[adjust]{header}
 \DeclareStringOption[sansserif]{headings}
@@ -160,6 +161,10 @@
 % \label{sec:call-base-class}
 %
 % The parent class is called with a pre-defined set of options.
+% However, some of the options are modified depending on class
+% options, such as |format|. For more info about these specific
+% configurations, check the section~\ref{sec:misc-page-style} about
+% the |format| option.
 % The following options are called explicitly:
 % \begin{itemize}
 % \item Put the bibliography to the table of contents.
@@ -188,8 +193,10 @@
 %     \begin{tabular}{ll}
 %         bibliography = totoc   & display bibliography in TOC \\
 %         BCOR         = (0mm)   & binding correction for margins \\
-%         DIV          = 9       & page division factor  \\
-%         fontsize     = 11pt    & set font size \\
+%         DIV          = 9       & page division factor (see also
+%         section \ref{sec:misc-page-style}) \\
+%         fontsize     = 11pt    & set font size (see also section
+%         \ref{sec:misc-page-style}) \\
 %         footinclude  = no      & include footer in DIV calc \\
 %         headinclude  = yes     & include header in DIV calc \\
 %         headsepline  = (no)    & separate header+text with line \\

--- a/dtx/ktx-misc-style.dtx
+++ b/dtx/ktx-misc-style.dtx
@@ -88,13 +88,16 @@
 %   usually. Consider the following calculation: One A4 page measures
 %   a width of 210mm, i.e. the text is spread over 140mm. Now multiply
 %   this value with the golden section for a nice text height. The
-%   height then is 226.5mm or 595pt (1mm = 2.845pt). With a leading of
-%   14pt, this equals 42 lines (-2pt because last line does not need
-%   leading).
+%   height then is 226.5mm or 644.5pt (1mm = 2.845pt). Subtracting
+%   about 30pt for the header which should be included in these
+%   calculations, there are 614.5pt left for the main text. With a
+%   leading of 14pt, 44 lines therefore is a good length. This yields
+%   a text height of 613pt which is close to the ideal value (616
+%   minus 3 because the last line does not need leading).
 %
 %   The top margin is modified as well: Set it to be the same as the
-%   inner margin. This corresponds to 1/6 of the text width (1in is
-%   the Latex standard offset).
+%   inner margin. This corresponds to roughly 59.5pt (1in is the Latex
+%   standard offset).
 %
 %   Skips between paragraphs are set to 0pt (with no variable space).
 %   A more relaxed option would be:
@@ -103,8 +106,8 @@
 %    \begin{macrocode}
 \RequirePackage{leading}
 \leading{14pt}
-\setlength{\textheight}{42\baselineskip-2pt}
-\setlength{\topmargin}{0.16666\textwidth-1in}
+\setlength{\topmargin}{59.5pt-1in}
+\setlength{\textheight}{613pt}
 \setlength{\parskip}{0pt}
 %    \end{macrocode}
 % \end{macro}

--- a/dtx/ktx-misc-style.dtx
+++ b/dtx/ktx-misc-style.dtx
@@ -76,7 +76,6 @@
 % \subsection{Miscellaneous Page Style}
 % \label{sec:misc-page-style}
 %
-% \begin{macro}{pagelayout}
 %   This section fixes the page layout completely. The base class was
 %   called with DIV=9, i.e. the available space (horizontally and
 %   vertically) is divided in 9x9 equal sections. Six out of nine
@@ -109,6 +108,36 @@
 \setlength{\topmargin}{59.5pt-1in}
 \setlength{\textheight}{613pt}
 \setlength{\parskip}{0pt}
+%    \end{macrocode}
+%
+% \begin{macro}{format}
+%   The calculation of the text width and height as described above
+%   follows recommendations from typography and guarantees an optimal
+%   text spread. One of the most important aspects in this case is the
+%   readibility of lines, i.e. the line length should (on average) not
+%   exceed a certain number of characters.
+%
+%   Besides, the layout uses both the very classical division of the
+%   page into 9x9 fields as well as the golden section for text width
+%   and height. However, this class also provides modifications of
+%   these settings with the |format| option.
+%
+%   The option |format=enlarge| increases the text spread over the
+%   page while switching to a font size of 12pt (in the standard
+%   setting the size is 11pt). To maintain optimal readability, the
+%   page is divided to 10x10 fields instead, 7 of which are used for
+%   the main text. Again, the text height is calculated following the
+%   golden section. The leading is extended to 16.15pt which allows 40
+%   lines of text in the given text height of 642pt.
+%    \begin{macrocode}
+\IfEqCase*{\ktx@format}{%
+  {standard}{\relax}%
+  {enlarge}{%
+    \KOMAoptions{fontsize=12pt, DIV=10}
+    \leading{16.15pt}
+    \setlength{\topmargin}{49pt-1in}
+    \setlength{\textheight}{642pt}}%
+}[\ktx@error{Unknown format: "\ktx@format"}{}]
 %    \end{macrocode}
 % \end{macro}
 %

--- a/dtx/ktx-titlepage.dtx
+++ b/dtx/ktx-titlepage.dtx
@@ -199,20 +199,24 @@
 %   Now define the actual content of the title page.
 %    \begin{macrocode}
 %<*thesis>
-\titlehead{\ktx@tp@leftlogo\hfill\ktx@tp@rightlogo\vspace{5em}}
+\titlehead{\ktx@tp@leftlogo\hfill\ktx@tp@rightlogo\vspace*{3em minus 2em}}
 \subject{\ktx@tp@type}
 \author{%
   \IfLanguageName{ngerman}{%
     angefertigt von\\[3mm]
     \textbf{\large \ktx@tp@author}\\[3mm]
     aus \ktx@tp@address\\[5mm]
-    am \ktx@tp@institute}{%
+    am \ktx@tp@institute
+    \vspace*{10mm}}{%
     prepared by\\[3mm]
     \textbf{\large \ktx@tp@author}\\[3mm]
     from \ktx@tp@address\\[5mm]
-    at the \ktx@tp@institute}
+    at the \ktx@tp@institute
+    \vspace*{10mm}}
 }
-\title{\ktx@tp@title\vskip 2em\ktx@tp@titlealt\vskip 1em}
+\title{\vspace*{0pt minus 1.0em}\ktx@tp@title\vskip 0pt%
+  \vspace*{2em minus 1.0em}\ktx@tp@titlealt\vskip 0pt%
+  \vspace*{1em minus 1.5em}}
 \publishers{%
 \newdate{begindate}{\ktx@tp@begindate@dd}{\ktx@tp@begindate@mm}{\ktx@tp@begindate@yyyy}%
 \newdate{enddate}{\ktx@tp@enddate@dd}{\ktx@tp@enddate@mm}{\ktx@tp@enddate@yyyy}
@@ -222,14 +226,14 @@
   \ifdefstring{\ktx@tp@thesisnumber}{\empty}{}{%
   \bfseries Arbeitsnummer:&\begin{minipage}[t]%
     {0.76\textwidth-4\tabcolsep}
-    \ktx@tp@thesisnumber\end{minipage}\\&\\
+    \ktx@tp@thesisnumber\end{minipage}\\[3mm]
   }
   \bfseries Bearbeitungszeit:&\begin{minipage}[t]%
     {0.76\textwidth-4\tabcolsep}
-    \ktx@dateformat@de\displaydate{begindate} bis \displaydate{enddate}\end{minipage}\\&\\
+    \ktx@dateformat@de\displaydate{begindate} bis \displaydate{enddate}\end{minipage}\\[3mm]
   \bfseries Erstgutachter/in:&\begin{minipage}[t]%
     {0.76\textwidth-4\tabcolsep}
-    \ktx@tp@firstref\end{minipage}\\&\\
+    \ktx@tp@firstref\end{minipage}\\[3mm]
   \bfseries Zweitgutachter/in:&\begin{minipage}[t]%
     {0.76\textwidth-4\tabcolsep}%
     \ktx@tp@secondref\end{minipage}\\
@@ -237,19 +241,19 @@
   \ifdefstring{\ktx@tp@thesisnumber}{\empty}{}{%
   \bfseries Thesis number:&\begin{minipage}[t]%
     {0.76\textwidth-4\tabcolsep}
-    \ktx@tp@thesisnumber\end{minipage}\\&\\
+    \ktx@tp@thesisnumber\end{minipage}\\[3mm]
   }
   \bfseries Thesis period:&\begin{minipage}[t]%
     {0.76\textwidth-4\tabcolsep}
-    \ktx@dateformat@gb\displaydate{begindate} until \displaydate{enddate}\end{minipage}\\&\\
+    \ktx@dateformat@gb\displaydate{begindate} until \displaydate{enddate}\end{minipage}\\[3mm]
   \ifdefstring{\ktx@tp@addsupervisor}{\empty}{}{%
   \bfseries Supervisor:&\begin{minipage}[t]%
     {0.76\textwidth-4\tabcolsep}
-    \ktx@tp@addsupervisor\end{minipage}\\&\\
+    \ktx@tp@addsupervisor\end{minipage}\\[3mm]
   }
   \bfseries First referee:&\begin{minipage}[t]%
     {0.76\textwidth-4\tabcolsep}
-    \ktx@tp@firstref\end{minipage}\\&\\
+    \ktx@tp@firstref\end{minipage}\\[3mm]
   \bfseries Second referee:&\begin{minipage}[t]%
     {0.76\textwidth-4\tabcolsep}
     \ktx@tp@secondref\end{minipage}\\


### PR DESCRIPTION
This branch includes another page layout which is – generally speaking – slightly bigger than the standard. Font size and leading is increased to 12pt and 16pt, respectively; the margins are decreased. Exact numbers and more changes TBC.

The decision to include this additional page layout is mainly motivated by the feedback that I got from a couple of people: they see the white spaces around the page as a "waste of space" and do not understand why the font size should be that small.