### PR TITLE
Added missing whitespace in bibliography

### DIFF
--- a/dtx/ktx-bibliography.dtx
+++ b/dtx/ktx-bibliography.dtx
@@ -300,6 +300,7 @@
         \usebibmacro{authorstrg}}% removed brace
       \ifentrytype{article}{% added
         \iffieldundef{usera}{}{% added
+          \setunit{\space}%
           \printfield{usera}}% added
       }% added
     }% added


### PR DESCRIPTION
For bibliography entries with author + collaboration there was a
whitespace missing in front of the opening parenthesis of the
collaboration. This has now been added. Fixed #10 