### PR TITLE
Make all class options available

### DIFF
--- a/kTheTex-bundle.ins
+++ b/kTheTex-bundle.ins
@@ -54,34 +54,34 @@ ktxreprt.cls and ktxthss.cls.
 \endpreamble
 
 \generate{\file{ktxreprt.cls}{%
-            \from{kTheTex-bundle.dtx}{report}%
-            \from{dtx/ktx-base.dtx}{report}%
-            \from{dtx/ktx-debug.dtx}{report}%
-            \from{dtx/ktx-font.dtx}{report}%
-            \from{dtx/ktx-drafting.dtx}{report}%
-            \from{dtx/ktx-misc-style.dtx}{report}%
-            \from{dtx/ktx-headings.dtx}{report}%
-            \from{dtx/ktx-headfoot.dtx}{report}%
-            \from{dtx/ktx-floats.dtx}{report}%
-            \from{dtx/ktx-bibliography.dtx}{report}%
-            \from{dtx/ktx-titlepage.dtx}{report}%
-            \from{dtx/ktx-toc.dtx}{report}%
-            \from{dtx/ktx-references.dtx}{report}
+            \from{kTheTex-bundle.dtx}{report,options}%
+            \from{dtx/ktx-base.dtx}{report,options}%
+            \from{dtx/ktx-debug.dtx}{report,options}%
+            \from{dtx/ktx-font.dtx}{report,options}%
+            \from{dtx/ktx-drafting.dtx}{report,options}%
+            \from{dtx/ktx-misc-style.dtx}{report,options}%
+            \from{dtx/ktx-headings.dtx}{report,options}%
+            \from{dtx/ktx-headfoot.dtx}{report,options}%
+            \from{dtx/ktx-floats.dtx}{report,options}%
+            \from{dtx/ktx-bibliography.dtx}{report,options}%
+            \from{dtx/ktx-titlepage.dtx}{report,options}%
+            \from{dtx/ktx-toc.dtx}{report,options}%
+            \from{dtx/ktx-references.dtx}{report,options}
           }
           \file{ktxthss.cls}{%
-            \from{kTheTex-bundle.dtx}{thesis}%
-            \from{dtx/ktx-base.dtx}{thesis}%
-            \from{dtx/ktx-debug.dtx}{thesis}%
-            \from{dtx/ktx-font.dtx}{thesis}%
-            \from{dtx/ktx-drafting.dtx}{thesis}%
-            \from{dtx/ktx-misc-style.dtx}{thesis}%
-            \from{dtx/ktx-headings.dtx}{thesis}%
-            \from{dtx/ktx-headfoot.dtx}{thesis}%
-            \from{dtx/ktx-floats.dtx}{thesis}%
-            \from{dtx/ktx-bibliography.dtx}{thesis}%
-            \from{dtx/ktx-titlepage.dtx}{thesis}%
-            \from{dtx/ktx-toc.dtx}{thesis}%
-            \from{dtx/ktx-references.dtx}{thesis}
+            \from{kTheTex-bundle.dtx}{thesis,options}%
+            \from{dtx/ktx-base.dtx}{thesis,options}%
+            \from{dtx/ktx-debug.dtx}{thesis,options}%
+            \from{dtx/ktx-font.dtx}{thesis,options}%
+            \from{dtx/ktx-drafting.dtx}{thesis,options}%
+            \from{dtx/ktx-misc-style.dtx}{thesis,options}%
+            \from{dtx/ktx-headings.dtx}{thesis,options}%
+            \from{dtx/ktx-headfoot.dtx}{thesis,options}%
+            \from{dtx/ktx-floats.dtx}{thesis,options}%
+            \from{dtx/ktx-bibliography.dtx}{thesis,options}%
+            \from{dtx/ktx-titlepage.dtx}{thesis,options}%
+            \from{dtx/ktx-toc.dtx}{thesis,options}%
+            \from{dtx/ktx-references.dtx}{thesis,options}
           }
           \file{ktxbbltx.sty}{%
             \from{dtx/ktx-bibliography.dtx}{package}%


### PR DESCRIPTION
While introducing various class options, they were only made available if the tag options is given in the file used the generate the classes. That tag had been missing, so only the default options were available within the classes. The tag has now been added.