### PR TITLE
[WIP] general review of spacing around headings

### DIFF
--- a/dtx/ktx-headings.dtx
+++ b/dtx/ktx-headings.dtx
@@ -120,8 +120,8 @@
     \renewcommand*{\sectionformat}{\ktx@sectionformat}%
     \renewcommand*{\subsectionformat}{\ktx@subsectionformat}%
     \renewcommand*{\subsubsectionformat}{\ktx@subsubsectionformat}%
-    \addtokomafont{sectioning}{\normalsize\mdseries\rmfamily}%
-    \setkomafont{section}{\ktx@lowcaps}%
+    \setkomafont{sectioning}{\normalsize\mdseries\rmfamily}%
+    \setkomafont{section}{\mbox{\normalsize\vphantom{f}}\ktx@lowcaps}%
     \setkomafont{subsection}{\ktx@swshape}%
     \setkomafont{subsubsection}{\ktx@swshape}%
     \setkomafont{paragraph}{\textsc}%

--- a/dtx/ktx-headings.dtx
+++ b/dtx/ktx-headings.dtx
@@ -127,12 +127,16 @@
     \setkomafont{paragraph}{\textsc}%
     \addtokomafont{pagehead}{\small}%
     \RedeclareSectionCommand[%
-       beforeskip=-1\baselineskip plus 0.3\baselineskip,%
+       beforeskip=-1\baselineskip,%
+       afterskip=1\baselineskip,%
+       ]{chapter}
+    \RedeclareSectionCommand[%
+       beforeskip=-16.37pt,%
        afterskip=1\baselineskip,%
        ]{section}
     \RedeclareSectionCommand[%
        beforeskip=-1\baselineskip,%
-       afterskip=1\baselineskip plus 0.3\baselineskip,%
+       afterskip=1\baselineskip,%
        ]{subsection}
     \RedeclareSectionCommand[%
        beforeskip=-1\baselineskip,%


### PR DESCRIPTION
When looking at the current definitions in the class files, there are some issues to be fixed concerning the spacing around headings. Step by step, this pull request will include invidual fixes of these spacings. As a first step, I reviewed the Bringhurst-style headings and defined the spacing around them to be exactly the height of one line of text.